### PR TITLE
reverted rabbitmq operator update

### DIFF
--- a/prototypes/rabbitmq-operator/vendir/vendir-data.ytt.yaml
+++ b/prototypes/rabbitmq-operator/vendir/vendir-data.ytt.yaml
@@ -5,5 +5,5 @@ prototypes:
     kind: helm
     repo: helmChart
     url: https://charts.bitnami.com/bitnami
-    version: 4.4.1
+    version: 4.3.24
 


### PR DESCRIPTION
vendir has issues pulling the change. PR was merged accidentally